### PR TITLE
ci: GHCR release + smoke logs + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Ethanbarzen-glitch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build images (compose)
+        run: docker compose build
+
+      - name: Tag & push (api)
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/buildaxis-auth-api
+          docker tag buildaxis-auth-api $IMAGE:${{ github.ref_name }}
+          docker tag buildaxis-auth-api $IMAGE:latest
+          docker push $IMAGE:${{ github.ref_name }}
+          docker push $IMAGE:latest
+
+      - name: Tag & push (projects)
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/buildaxis-auth-projects
+          docker tag buildaxis-auth-projects $IMAGE:${{ github.ref_name }}
+          docker tag buildaxis-auth-projects $IMAGE:latest
+          docker push $IMAGE:${{ github.ref_name }}
+          docker push $IMAGE:latest
+
+      - name: Tag & push (teams)
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/buildaxis-auth-teams
+          docker tag buildaxis-auth-teams $IMAGE:${{ github.ref_name }}
+          docker tag buildaxis-auth-teams $IMAGE:latest
+          docker push $IMAGE:${{ github.ref_name }}
+          docker push $IMAGE:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,17 @@
 name: release
 on:
   push:
-    tags: [ 'v*' ]
+    tags: ['v*']
   workflow_dispatch: {}
 
 permissions:
   contents: read
   packages: write
+
+env:
+  REGISTRY: ghcr.io
+  ORG: ${{ github.repository_owner }}
+  TAG: ${{ github.ref_name }}
 
 jobs:
   publish:
@@ -18,33 +23,26 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build images (compose)
         run: docker compose build
 
-      - name: Tag & push (api)
+      - name: Tag images for GHCR
         run: |
-          IMAGE=ghcr.io/${{ github.repository_owner }}/buildaxis-auth-api
-          docker tag buildaxis-auth-api $IMAGE:${{ github.ref_name }}
-          docker tag buildaxis-auth-api $IMAGE:latest
-          docker push $IMAGE:${{ github.ref_name }}
-          docker push $IMAGE:latest
+          for svc in api projects teams; do
+            src="buildaxis-auth-$svc"
+            dst="${REGISTRY}/${ORG}/buildaxis-auth-$svc"
+            docker tag "$src" "$dst:${TAG}"
+            docker tag "$src" "$dst:latest"
+          done
 
-      - name: Tag & push (projects)
+      - name: Push images
         run: |
-          IMAGE=ghcr.io/${{ github.repository_owner }}/buildaxis-auth-projects
-          docker tag buildaxis-auth-projects $IMAGE:${{ github.ref_name }}
-          docker tag buildaxis-auth-projects $IMAGE:latest
-          docker push $IMAGE:${{ github.ref_name }}
-          docker push $IMAGE:latest
-
-      - name: Tag & push (teams)
-        run: |
-          IMAGE=ghcr.io/${{ github.repository_owner }}/buildaxis-auth-teams
-          docker tag buildaxis-auth-teams $IMAGE:${{ github.ref_name }}
-          docker tag buildaxis-auth-teams $IMAGE:latest
-          docker push $IMAGE:${{ github.ref_name }}
-          docker push $IMAGE:latest
+          for svc in api projects teams; do
+            repo="${REGISTRY}/${ORG}/buildaxis-auth-$svc"
+            docker push "$repo:${TAG}"
+            docker push "$repo:latest"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  ORG: ${{ github.repository_owner }}
   TAG: ${{ github.ref_name }}
 
 jobs:
@@ -30,11 +29,14 @@ jobs:
       - name: Build images (compose)
         run: docker compose build
 
+      - name: Lowercase owner for GHCR path
+        run: echo "ORG_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
       - name: Tag images for GHCR
         run: |
           for svc in api projects teams; do
             src="buildaxis-auth-$svc"
-            dst="${REGISTRY}/${ORG}/buildaxis-auth-$svc"
+            dst="${REGISTRY}/${ORG_LC}/buildaxis-auth-$svc"
             docker tag "$src" "$dst:${TAG}"
             docker tag "$src" "$dst:latest"
           done
@@ -42,7 +44,7 @@ jobs:
       - name: Push images
         run: |
           for svc in api projects teams; do
-            repo="${REGISTRY}/${ORG}/buildaxis-auth-$svc"
+            repo="${REGISTRY}/${ORG_LC}/buildaxis-auth-$svc"
             docker push "$repo:${TAG}"
             docker push "$repo:latest"
           done

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,19 +24,13 @@ jobs:
       - name: Run smoke
         run: ./scripts/smoke.sh
 
-      - name: Dump compose logs on failure
-        if: ${{ failure() }}
-        run: |
-          docker compose ps > compose.ps.txt || true
-          docker compose logs --no-color > compose.log || true
+      - name: Dump compose logs
+        if: failure()
+        run: docker compose logs --no-color > compose.log || true
 
       - name: Upload logs
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: compose-logs
-          path: |
-            compose.log
-            compose.ps.txt
-          if-no-files-found: ignore
-          retention-days: 7
+          path: compose.log

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Dump compose logs
         if: failure()
-        run: docker compose logs --no-color > compose.log || true
+        run: docker compose logs --no-color > compose.log
 
       - name: Upload logs
         if: failure()


### PR DESCRIPTION
Add release workflow to push images to GHCR on tags; only upload compose logs on failure; add CODEOWNERS.