### PR TITLE
ci(smoke): assert healthz + JWKS

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,29 +8,48 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 
-      - name: Start stack
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start stack (build + wait for health)
         run: docker compose up -d --build --wait
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Assert healthz for all services
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sf http://localhost:9001/healthz >/dev/null
+          curl -sf http://localhost:9010/healthz >/dev/null
+          curl -sf http://localhost:9020/healthz >/dev/null
 
-      - name: Ensure smoke is executable
-        run: chmod +x scripts/smoke.sh
+      - name: Assert JWKS exists (api)
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sf http://localhost:9001/.well-known/jwks.json | grep -q '"keys"'
 
-      - name: Run smoke
-        run: ./scripts/smoke.sh
-
-      - name: Dump compose logs
+      - name: Dump compose logs on failure
         if: failure()
-        run: docker compose logs --no-color > compose.log
+        run: docker compose logs --no-color > compose.logs.txt
 
-      - name: Upload logs
+      - name: Upload logs (only on failure)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: compose-logs
-          path: compose.log
+          path: compose.logs.txt
+
+      - name: Teardown
+        if: always()
+        run: docker compose down --volumes


### PR DESCRIPTION
Assert /healthz on api/projects/teams and JWKS presence; upload logs only on failure.